### PR TITLE
eat: implement bundled searches for multi-status filtering

### DIFF
--- a/src/components/map-listings/components/filters/FilterPanel.tsx
+++ b/src/components/map-listings/components/filters/FilterPanel.tsx
@@ -114,10 +114,15 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
     return filters.activeListingDays !== undefined;
   };
 
-  // Handle active listing filter change
+  // Handle active listing filter change (supports bundled searches - doesn't clear other status filters)
   const handleActiveFilterChange = (value: typeof filters.activeListingDays) => {
-    onFiltersChange({ ...filters, activeListingDays: value, soldListingDays: undefined, unavailableListingDays: undefined });
+    onFiltersChange({ ...filters, activeListingDays: value });
     setIsActiveOpen(false);
+  };
+
+  // Handle clearing active filter (click on colored bar)
+  const handleClearActiveFilter = () => {
+    onFiltersChange({ ...filters, activeListingDays: undefined });
   };
 
   // Sold listing filter options
@@ -163,10 +168,15 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
     return !!filters.soldListingDays;
   };
 
-  // Handle sold listing filter change
+  // Handle sold listing filter change (supports bundled searches - doesn't clear other status filters)
   const handleSoldFilterChange = (value: typeof filters.soldListingDays) => {
-    onFiltersChange({ ...filters, soldListingDays: value, activeListingDays: undefined, unavailableListingDays: undefined });
+    onFiltersChange({ ...filters, soldListingDays: value });
     setIsSoldOpen(false);
+  };
+
+  // Handle clearing sold filter (click on colored bar)
+  const handleClearSoldFilter = () => {
+    onFiltersChange({ ...filters, soldListingDays: undefined });
   };
 
   // Unavailable listing filter options (same as sold)
@@ -212,10 +222,15 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
     return !!filters.unavailableListingDays;
   };
 
-  // Handle unavailable listing filter change
+  // Handle unavailable listing filter change (supports bundled searches - doesn't clear other status filters)
   const handleUnavailableFilterChange = (value: typeof filters.unavailableListingDays) => {
-    onFiltersChange({ ...filters, unavailableListingDays: value, activeListingDays: undefined, soldListingDays: undefined });
+    onFiltersChange({ ...filters, unavailableListingDays: value });
     setIsUnavailableOpen(false);
+  };
+
+  // Handle clearing unavailable filter (click on colored bar)
+  const handleClearUnavailableFilter = () => {
+    onFiltersChange({ ...filters, unavailableListingDays: undefined });
   };
 
   // Handle click outside to close price filter dropdown
@@ -479,8 +494,7 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
 
       {/* Active Listings Filter Button */}
       <div ref={activeFilterRef} style={{ position: "relative", marginBottom: "12px" }}>
-        <button
-          onClick={() => setIsActiveOpen(!isActiveOpen)}
+        <div
           style={{
             width: "100%",
             padding: "0",
@@ -488,19 +502,24 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
             border: "1px solid #d1d5db",
             borderRadius: "6px",
             fontSize: "14px",
-            cursor: "pointer",
             display: "flex",
             overflow: "hidden",
           }}
         >
           <div
+            onClick={(e) => {
+              e.stopPropagation();
+              handleClearActiveFilter();
+            }}
             style={{
               width: "48px",
               backgroundColor: isActiveFilterActive() ? "#10b981" : "#e5e7eb",
               flexShrink: 0,
+              cursor: isActiveFilterActive() ? "pointer" : "default",
             }}
           />
-          <div
+          <button
+            onClick={() => setIsActiveOpen(!isActiveOpen)}
             style={{
               flex: 1,
               padding: "8px 12px",
@@ -510,6 +529,9 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
               textAlign: "left",
               color: "#1f2937",
               fontWeight: "500",
+              cursor: "pointer",
+              backgroundColor: "transparent",
+              border: "none",
             }}
           >
             <span>Active: {formatActiveLabel()}</span>
@@ -520,8 +542,8 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
                 transition: "transform 0.2s"
               }}
             />
-          </div>
-        </button>
+          </button>
+        </div>
 
         {/* Active Filter Dropdown */}
         {isActiveOpen && (
@@ -579,8 +601,7 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
 
       {/* Sold Listings Filter Button */}
       <div ref={soldFilterRef} style={{ position: "relative", marginBottom: "12px" }}>
-        <button
-          onClick={() => setIsSoldOpen(!isSoldOpen)}
+        <div
           style={{
             width: "100%",
             padding: "0",
@@ -588,19 +609,24 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
             border: "1px solid #d1d5db",
             borderRadius: "6px",
             fontSize: "14px",
-            cursor: "pointer",
             display: "flex",
             overflow: "hidden",
           }}
         >
           <div
+            onClick={(e) => {
+              e.stopPropagation();
+              handleClearSoldFilter();
+            }}
             style={{
               width: "48px",
               backgroundColor: isSoldFilterActive() ? "#8b7fa8" : "#e5e7eb",
               flexShrink: 0,
+              cursor: isSoldFilterActive() ? "pointer" : "default",
             }}
           />
-          <div
+          <button
+            onClick={() => setIsSoldOpen(!isSoldOpen)}
             style={{
               flex: 1,
               padding: "8px 12px",
@@ -610,6 +636,9 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
               textAlign: "left",
               color: "#1f2937",
               fontWeight: "500",
+              cursor: "pointer",
+              backgroundColor: "transparent",
+              border: "none",
             }}
           >
             <span>Sold: {formatSoldLabel()}</span>
@@ -620,8 +649,8 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
                 transition: "transform 0.2s"
               }}
             />
-          </div>
-        </button>
+          </button>
+        </div>
 
         {/* Sold Filter Dropdown */}
         {isSoldOpen && (
@@ -681,8 +710,7 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
 
       {/* Unavailable Listings Filter Button */}
       <div ref={unavailableFilterRef} style={{ position: "relative", marginBottom: "12px" }}>
-        <button
-          onClick={() => setIsUnavailableOpen(!isUnavailableOpen)}
+        <div
           style={{
             width: "100%",
             padding: "0",
@@ -690,19 +718,24 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
             border: "1px solid #d1d5db",
             borderRadius: "6px",
             fontSize: "14px",
-            cursor: "pointer",
             display: "flex",
             overflow: "hidden",
           }}
         >
           <div
+            onClick={(e) => {
+              e.stopPropagation();
+              handleClearUnavailableFilter();
+            }}
             style={{
               width: "48px",
               backgroundColor: isUnavailableFilterActive() ? "#f59e0b" : "#e5e7eb",
               flexShrink: 0,
+              cursor: isUnavailableFilterActive() ? "pointer" : "default",
             }}
           />
-          <div
+          <button
+            onClick={() => setIsUnavailableOpen(!isUnavailableOpen)}
             style={{
               flex: 1,
               padding: "8px 12px",
@@ -712,6 +745,9 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
               textAlign: "left",
               color: "#1f2937",
               fontWeight: "500",
+              cursor: "pointer",
+              backgroundColor: "transparent",
+              border: "none",
             }}
           >
             <span>Unavailable: {formatUnavailableLabel()}</span>
@@ -722,8 +758,8 @@ export function FilterPanel({ filters, onFiltersChange, apiKey }: FilterPanelPro
                 transition: "transform 0.2s"
               }}
             />
-          </div>
-        </button>
+          </button>
+        </div>
 
         {/* Unavailable Filter Dropdown */}
         {isUnavailableOpen && (

--- a/src/components/map-listings/types/index.ts
+++ b/src/components/map-listings/types/index.ts
@@ -98,9 +98,10 @@ export interface MapFilters {
   maxSqft?: number | null; // null represents "Max" (no limit)
   openHouse?: "all" | "today" | "thisWeek" | "thisWeekend" | "anytime";
   maxMaintenanceFee?: number | null; // null represents "Max" (no limit)
-  activeListingDays?: "1" | "3" | "7" | "30" | "90" | "all" | "15+" | "30+" | "60+" | "90+"; // Active listing date filter
-  soldListingDays?: "1" | "3" | "7" | "30" | "90" | "180" | "360" | "2025" | "2024" | "2023" | "2022" | "2021" | "2020" | "2019" | "2018" | "2017" | "2016" | "2015" | "2014" | "2013" | "2012" | "2011" | "2010" | "2009" | "2008" | "2007"; // Sold listing date filter
-  unavailableListingDays?: "1" | "3" | "7" | "30" | "90" | "180" | "360" | "2025" | "2024" | "2023" | "2022" | "2021" | "2020" | "2019" | "2018" | "2017" | "2016" | "2015" | "2014" | "2013" | "2012" | "2011" | "2010" | "2009" | "2008" | "2007"; // Unavailable listing date filter
+  // Status filters - can be enabled/disabled independently for bundled searches
+  activeListingDays?: "1" | "3" | "7" | "30" | "90" | "all" | "15+" | "30+" | "60+" | "90+"; // Active listing date filter (undefined = off)
+  soldListingDays?: "1" | "3" | "7" | "30" | "90" | "180" | "360" | "2025" | "2024" | "2023" | "2022" | "2021" | "2020" | "2019" | "2018" | "2017" | "2016" | "2015" | "2014" | "2013" | "2012" | "2011" | "2010" | "2009" | "2008" | "2007"; // Sold listing date filter (undefined = off)
+  unavailableListingDays?: "1" | "3" | "7" | "30" | "90" | "180" | "360" | "2025" | "2024" | "2023" | "2022" | "2021" | "2020" | "2019" | "2018" | "2017" | "2016" | "2015" | "2014" | "2013" | "2012" | "2011" | "2010" | "2009" | "2008" | "2007"; // Unavailable listing date filter (undefined = off)
 }
 
 export interface ListingResult {


### PR DESCRIPTION
Enable users to view Active, Sold, and Unavailable listings simultaneously on the map using bundled search API.

Key features:
- Users can toggle multiple status filters independently (Active, Sold, Unavailable)
- Clickable colored bars on status filters to enable/disable each independently
- Automatic bundled POST request when 2+ status filters are active
- Single status filter maintains backward compatibility with GET requests
- All common filters (price, beds, baths, etc.) apply across all status types
- API automatically merges results from all queries

Implementation details:
- Updated MapFilters type to support independent status filter selection
- Modified FilterPanel UI with clickable colored bars for toggle behavior
- Implemented buildStatusQueryParams helper to construct query objects per status
- Global parameters (cluster, clusterFields) sent in URL query string
- Search filters (status, dates, price, etc.) sent in POST body queries array
- Fixed default state: Active filter now undefined by default (auto-defaults to all only if no filters set)
- Unavailable filter uses status=U with unavailableDate to differentiate from Sold listings

Status filter definitions:
- Active: status=A with optional date filtering
- Sold: status=U + lastStatus=Sld with soldDate filtering
- Unavailable: status=U with unavailableDate filtering (includes all non-sold unavailable statuses)