### PR TITLE
feat: add configurable API endpoint to chatbot

### DIFF
--- a/.claude/commands/end.md
+++ b/.claude/commands/end.md
@@ -1,0 +1,35 @@
+---
+description: End session with quality checks, commit, and push
+---
+
+# /end - End session workflow
+
+## 1. Quality Checks
+Run checks if applicable (skip any that don't exist in the project):
+- Linting
+- Build verification
+- Type checking
+
+If checks fail, fix the issues before proceeding.
+
+## 2. Session Summary
+- Run `git diff` to review all changes
+- Provide a concise summary of what was accomplished
+
+## 3. Branch
+- If already on a feature branch, stay on it
+- If on main, create a descriptive branch and switch to it (e.g. `feature/add-keyword-search`, `fix/authentication-bug`)
+
+## 4. Stage & Present Commit
+- Stage the relevant files
+- Present the proposed commit message to the user
+- **Wait for explicit approval before committing**
+- If the user requests changes to the message, revise and present again
+
+## 5. Commit & Push
+After user approves:
+- Create the commit
+- Push the branch to remote with `-u` flag
+- Output the GitHub PR creation URL: `https://github.com/<owner>/<repo>/compare/<branch>?expand=1`
+
+**Never merge to main. Never push to main.**

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -1,0 +1,12 @@
+---
+description: Start new session with git context review
+---
+
+# /start - Begin new session
+
+1. Run `git status` to check for uncommitted changes
+2. Run `git log --oneline -15` to review recent work
+3. Provide a concise summary:
+   - Any uncommitted or staged changes
+   - What was recently worked on (from commits)
+4. Ask what to work on this session

--- a/src/components/chatbot/chatbot.stories.tsx
+++ b/src/components/chatbot/chatbot.stories.tsx
@@ -174,50 +174,25 @@ This is a complete, working demonstration of the chatbot with all features:
 };
 
 /**
- * **Custom Branding**
+ * **Local Testing**
  *
- * This story shows how to white-label the chatbot with your brokerage's branding.
- * Customize the name, logo, colors, welcome message, and button position.
- *
- * **Perfect for:**
- * - Adding to your real estate website
- * - White-labeling for clients
- * - Matching your brand identity
+ * Same as the Working Demo but pointed at a local API server on port 3001.
+ * Run your local Repliers API proxy before using this story.
  */
-export const CustomBranding: Story = {
+export const LocalTesting: Story = {
   args: {
     repliersApiKey: SAMPLE_REPLIERS_API_KEY,
-    brokerageName: "Luxury Homes Toronto",
-    brokerageLogo:
-      "https://images.unsplash.com/photo-1560518883-ce09059eeffa?w=100&h=100&fit=crop",
-    primaryColor: "#1e40af",
-    position: "bottom-right",
+    repliersApiEndpoint: "http://localhost:3001",
+    openaiApiKey: undefined,
+    brokerageName: "Smart Homes Realty",
   },
   parameters: {
     docs: {
       description: {
         story: `
-Customize every aspect of the chatbot to match your brand:
+Same as Working Demo, but all Repliers API calls are routed to \`http://localhost:3001\`.
 
-**Branding Options:**
-- \`brokerageName\`: Your company name in the header
-- \`brokerageLogo\`: URL to your logo image
-- \`welcomeMessage\`: Custom greeting message
-- \`placeholder\`: Custom input placeholder text
-- \`primaryColor\`: Brand color (future feature)
-- \`position\`: "bottom-right" or "bottom-left"
-
-**Example Integration:**
-\`\`\`tsx
-<Chatbot
-  repliersApiKey="your-key"
-  openaiApiKey="your-openai-key"
-  brokerageName="Your Realty"
-  brokerageLogo="https://your-site.com/logo.png"
-  welcomeMessage="Welcome! How can I help you find your dream home?"
-  position="bottom-right"
-/>
-\`\`\`
+Start your local API server before using this story.
         `,
       },
     },

--- a/src/components/chatbot/chatbot.tsx
+++ b/src/components/chatbot/chatbot.tsx
@@ -46,6 +46,7 @@ import {
  */
 export function Chatbot({
   repliersApiKey,
+  repliersApiEndpoint,
   openaiApiKey,
   brokerageName = DEFAULT_BROKERAGE_NAME,
   brokerageLogo,
@@ -70,7 +71,8 @@ export function Chatbot({
     repliersApiKey,
     openaiApiKey,
     brokerageName,
-    welcomeMessage
+    welcomeMessage,
+    repliersApiEndpoint
   );
 
   // Suppress unused variable warnings

--- a/src/components/chatbot/hooks/useChatRuntime.ts
+++ b/src/components/chatbot/hooks/useChatRuntime.ts
@@ -40,12 +40,13 @@ export function useChatRuntime(
   repliersApiKey: string,
   openaiApiKey?: string,
   brokerageName: string = "Real Estate Assistant",
-  welcomeMessage: string = DEFAULT_WELCOME_MESSAGE
+  welcomeMessage: string = DEFAULT_WELCOME_MESSAGE,
+  repliersApiEndpoint?: string
 ): ChatRuntime {
   // Initialize services (memoized to avoid recreating on every render)
   const nlpService = useMemo(
-    () => new RepliersNLPService(repliersApiKey),
-    [repliersApiKey]
+    () => new RepliersNLPService(repliersApiKey, repliersApiEndpoint),
+    [repliersApiKey, repliersApiEndpoint]
   );
 
   const chatGPT = useMemo(

--- a/src/components/chatbot/services/repliersAPI.ts
+++ b/src/components/chatbot/services/repliersAPI.ts
@@ -69,8 +69,9 @@ export class RepliersNLPService {
   private baseUrl: string = "https://api.repliers.io";
   private currentNlpId: string | null = null;
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, baseUrl?: string) {
     this.apiKey = apiKey;
+    if (baseUrl) this.baseUrl = baseUrl;
   }
 
   /**

--- a/src/components/chatbot/types/index.ts
+++ b/src/components/chatbot/types/index.ts
@@ -5,6 +5,8 @@
 export interface ChatbotProps {
   /** Repliers API key (required for property search) */
   repliersApiKey: string;
+  /** Repliers API base URL (optional - defaults to https://api.repliers.io) */
+  repliersApiEndpoint?: string;
   /** OpenAI API key (optional - for enhanced conversation) */
   openaiApiKey?: string;
   /** Name of the brokerage to display in header */


### PR DESCRIPTION
Add `repliersApiEndpoint` prop to Chatbot, wired through useChatRuntime to RepliersNLPService. Enables local development and custom API proxies. Replace CustomBranding story with LocalTesting story targeting localhost:3001.