### PR TITLE
feat(ai-map-listings): add nlpEnv prop for multi-environment NLP endp…

### DIFF
--- a/src/components/ai-map-listings/ai-map-listings.stories.tsx
+++ b/src/components/ai-map-listings/ai-map-listings.stories.tsx
@@ -7,6 +7,13 @@ const meta: Meta<typeof AIMapListings> = {
   parameters: {
     layout: "fullscreen",
   },
+  argTypes: {
+    nlpEnv: {
+      control: { type: "select" },
+      options: ["prod", "dev", "local"],
+      description: "NLP API environment",
+    },
+  },
 };
 
 export default meta;
@@ -37,5 +44,19 @@ export const NlpTest: Story = {
     centerCalculation: "city",
     expandDirection: "up",
     expandedHeight: "100%",
+  },
+};
+
+export const LocalhostNlp: Story = {
+  args: {
+    apiKey: SAMPLE_API_KEY,
+    mapboxToken: SAMPLE_MAPBOX_TOKEN,
+    height: "100vh",
+    width: "100vw",
+    mapStyle: "mapbox://styles/mapbox/streets-v12",
+    centerCalculation: "city",
+    expandDirection: "up",
+    expandedHeight: "100%",
+    nlpEnv: "local",
   },
 };

--- a/src/components/ai-map-listings/ai-map-listings.tsx
+++ b/src/components/ai-map-listings/ai-map-listings.tsx
@@ -44,6 +44,7 @@ export function AIMapListings({
   showPropertyCount = true,
   expandDirection = "down",
   expandedHeight = "100%",
+  nlpEnv,
 }: AIMapListingsProps) {
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<mapboxgl.Map | null>(null);
@@ -1528,6 +1529,7 @@ export function AIMapListings({
         isDrawing={isDrawing}
         expandDirection={expandDirection}
         expandedHeight={expandedHeight}
+        nlpEnv={nlpEnv}
       />
 
       {/* Property Count Display */}

--- a/src/components/ai-map-listings/components/SearchPanel/SearchPanel.tsx
+++ b/src/components/ai-map-listings/components/SearchPanel/SearchPanel.tsx
@@ -31,6 +31,7 @@ export function SearchPanel({
   isDrawing = false,
   expandDirection = 'down',
   expandedHeight = '100%',
+  nlpEnv,
 }: SearchPanelProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
@@ -39,7 +40,7 @@ export function SearchPanel({
   const panelRef = useRef<HTMLDivElement>(null);
 
   const { processSearch, isProcessing, error, resetNlpId } =
-    useNLPSearch(apiKey);
+    useNLPSearch(apiKey, nlpEnv);
 
   // Add log entry
   const addLogEntry = useCallback((

--- a/src/components/ai-map-listings/components/SearchPanel/types.ts
+++ b/src/components/ai-map-listings/components/SearchPanel/types.ts
@@ -14,6 +14,7 @@ export interface SearchPanelProps {
   isDrawing?: boolean;
   expandDirection?: 'up' | 'down';
   expandedHeight?: 'fit' | '100%';
+  nlpEnv?: 'prod' | 'dev' | 'local';
 }
 
 export interface FilterState extends MapFilters {

--- a/src/components/ai-map-listings/hooks/useNLPSearch.ts
+++ b/src/components/ai-map-listings/hooks/useNLPSearch.ts
@@ -43,7 +43,13 @@ interface UseNLPSearchReturn {
   resetNlpId: () => void;
 }
 
-export function useNLPSearch(apiKey: string): UseNLPSearchReturn {
+const NLP_URLS = {
+  prod: 'https://api.repliers.io/nlp',
+  dev: 'https://dev.repliers.io/nlp',
+  local: 'http://localhost:3001/nlp',
+};
+
+export function useNLPSearch(apiKey: string, nlpEnv: 'prod' | 'dev' | 'local' = 'prod'): UseNLPSearchReturn {
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [nlpId, setNlpId] = useState<string | null>(null);
@@ -65,7 +71,7 @@ export function useNLPSearch(apiKey: string): UseNLPSearchReturn {
 
       console.log('🔍 NLP Request:', requestBody);
 
-      const response = await fetch('https://api.repliers.io/nlp', {
+      const response = await fetch(NLP_URLS[nlpEnv], {
         method: 'POST',
         headers: {
           'REPLIERS-API-KEY': apiKey,

--- a/src/components/ai-map-listings/types/index.ts
+++ b/src/components/ai-map-listings/types/index.ts
@@ -21,6 +21,8 @@ export interface AIMapListingsProps {
   expandDirection?: 'up' | 'down';
   /** Search panel expanded height - 'fit' (auto-sized) or '100%' (full viewport, default) */
   expandedHeight?: 'fit' | '100%';
+  /** NLP environment - controls which API endpoint is used */
+  nlpEnv?: 'prod' | 'dev' | 'local';
 }
 
 export interface ClusterFeature {


### PR DESCRIPTION
…oint switching

Adds a `nlpEnv` prop ('prod' | 'dev' | 'local') to AIMapListings, threaded through SearchPanel to useNLPSearch. Resolves the target URL from a NLP_URLS map, defaulting to prod. Includes a LocalhostNlp Storybook story and argType control for easy local dev testing.